### PR TITLE
Fixes order OnSendingHeaders actions are invoked to be consistent with HttpListener and Owin.

### DIFF
--- a/src/OwinHttpMessageHandler.Tests/CookieTests.cs
+++ b/src/OwinHttpMessageHandler.Tests/CookieTests.cs
@@ -61,6 +61,14 @@
             const string cookieName1 = "testcookie1";
 
             var uri = new Uri("http://localhost/");
+
+            AppFunc inner = async env =>
+            {
+                var context = new OwinContext(env);
+                context.Response.Headers.Append("Location", "/");
+                await context.Response.WriteAsync("Test");
+            };
+
             AppFunc appFunc = async env =>
             {
                 var context = new OwinContext(env);
@@ -68,7 +76,7 @@
                 {
                     context.Response.Cookies.Append(cookieName1, "c1");
                 }, null);
-                await context.Response.WriteAsync("Test");
+                await inner(env);
             };
 
             var handler = new OwinHttpMessageHandler(appFunc) { UseCookies = true };

--- a/src/OwinHttpMessageHandler.Tests/OnSendingHeadersTests.cs
+++ b/src/OwinHttpMessageHandler.Tests/OnSendingHeadersTests.cs
@@ -1,0 +1,145 @@
+﻿namespace System.Net.Http
+{
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Microsoft.Owin;
+    using Microsoft.Owin.Hosting;
+    using Microsoft.Owin.Testing;
+    using Nowin;
+    using Owin;
+    using Xunit;
+    using AppFunc = Func<Collections.Generic.IDictionary<string, object>, Threading.Tasks.Task>;
+    using OwinServerFactory = Microsoft.Owin.Host.HttpListener.OwinServerFactory;
+
+    public class OnSendingHeadersTests
+    {
+        const string CookieName1 = "testcookie1";
+        const string CookieName2 = "testcookie2";
+        private readonly Uri _uri = new Uri("http://localhost:8888/");
+        private readonly AppFunc _appFunc;
+
+        public OnSendingHeadersTests()
+        {
+            AppFunc inner = async env =>
+            {
+                var context = new OwinContext(env);
+                context.Response.StatusCode = 404;
+                await context.Response.WriteAsync("Test");
+            };
+
+            AppFunc inner2 = async env =>
+            {
+                var context = new OwinContext(env);
+                context.Response.OnSendingHeaders(_ =>
+                {
+                    if (context.Response.StatusCode ==  404)
+                    {
+                        context.Response.Cookies.Append(CookieName1, "c1");
+                    }
+                }, null);
+                await inner(env);
+            };
+
+            _appFunc = async env =>
+            {
+                var context = new OwinContext(env);
+                context.Response.OnSendingHeaders(_ =>
+                {
+                    if (context.Response.Headers.ContainsKey("Set-Cookie"))
+                    {
+                        context.Response.Cookies.Append(CookieName2, "c2");
+                    }
+                }, null);
+                await inner2(env);
+            };
+        }
+
+        [Fact]
+        public async Task Using_OwinHttpMessageHandler_then_should_have_2_cookies()
+        {
+            var handler = new OwinHttpMessageHandler(_appFunc)
+            {
+                UseCookies = true
+            };
+
+            using (var client = new HttpClient(handler)
+                {
+                    BaseAddress = _uri
+                })
+            {
+                var response = await client.GetAsync(_uri);
+
+                response.Headers.GetValues("Set-Cookie")
+                    .Should()
+                    .HaveCount(2);
+            }
+        }
+
+
+        [Fact]
+        public async Task Using_nowin_then_should_have_2_cookies()
+        {
+            using (var server = ServerBuilder
+                .New()
+                .SetEndPoint(new IPEndPoint(IPAddress.Any, _uri.Port))
+                .SetOwinApp(_appFunc)
+                .Build())
+            {
+                server.Start();
+
+                var handler = new HttpClientHandler
+                {
+                    UseCookies = true
+                };
+                using (var client = new HttpClient(handler)
+                {
+                    BaseAddress = _uri
+                })
+                {
+                    var response = await client.GetAsync(_uri);
+
+                    response.Headers.GetValues("Set-Cookie")
+                        .Should()
+                        .HaveCount(2);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Using_HttpListener_then_should_have_2_cookies()
+        {
+            using(WebApp.Start(_uri.ToString(), a => a.Run(ctx => _appFunc(ctx.Environment))))
+            {
+                var handler = new HttpClientHandler
+                {
+                    UseCookies = true
+                };
+                using (var client = new HttpClient(handler)
+                {
+                    BaseAddress = _uri
+                })
+                {
+                    var response = await client.GetAsync(_uri);
+
+                    response.Headers.GetValues("Set-Cookie")
+                        .Should()
+                        .HaveCount(2);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Using_TestServer_then_should_have_2_cookies()
+        {
+            var testServer = TestServer.Create(a1 => a1.Run(ctx => _appFunc(ctx.Environment)));
+            using (var client = testServer.HttpClient)
+            {
+                var response = await client.GetAsync(_uri);
+
+                response.Headers.GetValues("Set-Cookie")
+                    .Should()
+                    .HaveCount(2);
+            }
+        }
+    }
+}

--- a/src/OwinHttpMessageHandler.Tests/OnSendingHeadersTests.cs
+++ b/src/OwinHttpMessageHandler.Tests/OnSendingHeadersTests.cs
@@ -128,7 +128,7 @@
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Will fail because of bug in TestServer")]
         public async Task Using_TestServer_then_should_have_2_cookies()
         {
             var testServer = TestServer.Create(a1 => a1.Run(ctx => _appFunc(ctx.Environment)));

--- a/src/OwinHttpMessageHandler.Tests/OwinHttpMessageHandler.Tests.csproj
+++ b/src/OwinHttpMessageHandler.Tests/OwinHttpMessageHandler.Tests.csproj
@@ -38,9 +38,24 @@
     <Reference Include="FluentAssertions.Core">
       <HintPath>..\packages\FluentAssertions.3.0.107\lib\net45\FluentAssertions.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Owin.2.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Diagnostics">
+      <HintPath>..\packages\Microsoft.Owin.Diagnostics.3.0.1\lib\net45\Microsoft.Owin.Diagnostics.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Host.HttpListener">
+      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.3.0.1\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Hosting">
+      <HintPath>..\packages\Microsoft.Owin.Hosting.3.0.1\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Testing">
+      <HintPath>..\packages\Microsoft.Owin.Testing.3.0.1\lib\net45\Microsoft.Owin.Testing.dll</HintPath>
+    </Reference>
+    <Reference Include="Nowin">
+      <HintPath>..\packages\Nowin.0.15.1.0\lib\net45\Nowin.dll</HintPath>
     </Reference>
     <Reference Include="Owin">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
@@ -62,6 +77,7 @@
     <Compile Include="AutoRedirectTests.cs" />
     <Compile Include="AppFunc.cs" />
     <Compile Include="CookieTests.cs" />
+    <Compile Include="OnSendingHeadersTests.cs" />
     <Compile Include="OwinHttpMessageHandlerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StreamingTests.cs" />

--- a/src/OwinHttpMessageHandler.Tests/packages.config
+++ b/src/OwinHttpMessageHandler.Tests/packages.config
@@ -1,7 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FluentAssertions" version="3.0.107" targetFramework="net45" />
-  <package id="Microsoft.Owin" version="2.1.0" targetFramework="net45" />
+  <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
+  <package id="Microsoft.Owin.Diagnostics" version="3.0.1" targetFramework="net45" />
+  <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net45" />
+  <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net45" />
+  <package id="Microsoft.Owin.SelfHost" version="3.0.1" targetFramework="net45" />
+  <package id="Microsoft.Owin.Testing" version="3.0.1" targetFramework="net45" />
+  <package id="Nowin" version="0.15.1.0" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/OwinHttpMessageHandler/OwinHttpMessageHandler.cs
+++ b/src/OwinHttpMessageHandler/OwinHttpMessageHandler.cs
@@ -289,8 +289,8 @@
                     var prior = _sendingHeaders;
                     _sendingHeaders = () =>
                     {
-                        prior();
                         callback(state);
+                        prior();
                     };
                 });
 


### PR DESCRIPTION
Added test to check the order of OnSendingHeaders hooks in 2 MW are invoked in a consistent way.

(Microsoft.Owin.TestServer is broken too)